### PR TITLE
workaround dual-monitor panel width (show immediately)

### DIFF
--- a/TemplateCS/Addin/PanelFrame.cs
+++ b/TemplateCS/Addin/PanelFrame.cs
@@ -43,6 +43,9 @@ namespace $csprojectname$
         private const int GW_CHILD = 5;
         private const int GW_HWNDNEXT = 2;
 
+        private const int GWL_EXSTYLE = (-20);
+        private const int WS_EX_COMPOSITED = 0x02000000;
+
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         private struct RECT
         {
@@ -89,12 +92,10 @@ namespace $csprojectname$
             {
                 if (_visioWindow != null && _form != null)
                 {
-                    var childWindowHandle = _form.Handle;
-
                     _form.Hide();
 
-                    SetWindowLong(childWindowHandle, GWL_STYLE, WS_OVERLAPPED);
-                    SetParent(childWindowHandle, (IntPtr)0);
+                    SetWindowLong(_form.Handle, GWL_STYLE, WS_OVERLAPPED);
+                    SetParent(_form.Handle, (IntPtr)0);
 
                     _visioWindow.Close();
                     _visioWindow = null;
@@ -129,11 +130,9 @@ namespace $csprojectname$
 
                 if (_form != null)
                 {
-                    IntPtr childWindowHandle = _form.Handle;
-
                     _visioWindow = visioParentWindow.Windows.Add(
                         _form.Text,
-                        (int)VisWindowStates.visWSDockedRight | (int)VisWindowStates.visWSAnchorMerged,
+                        (int)VisWindowStates.visWSDockedRight | (int)VisWindowStates.visWSAnchorMerged | (int)VisWindowStates.visWSVisible,
                         VisWinTypes.visAnchorBarAddon,
                         0,
                         0,
@@ -145,18 +144,16 @@ namespace $csprojectname$
 
                     _visioWindow.BeforeWindowClosed += OnBeforeWindowClosed;
 
-                    _visioWindow.Visible = false;
-
                     var parentWindowHandle = (IntPtr)_visioWindow.WindowHandle32;
 
-                    SetWindowLong(childWindowHandle, GWL_STYLE, WS_CHILD);
-                    SetParent(childWindowHandle, parentWindowHandle);
+                    SetWindowLong(_form.Handle, GWL_STYLE, WS_CHILD);
+                    SetWindowLong(_form.Handle, GWL_EXSTYLE, WS_EX_COMPOSITED);
+                    SetParent(_form.Handle, parentWindowHandle);
 
                     _form.Show();
 
                     JiggleWindow(parentWindowHandle);
 
-                    _visioWindow.Visible = true;
                     _visioWindow.Activate();
 
                     retVal = _visioWindow;

--- a/TemplateVB/Addin/PanelFrame.vb
+++ b/TemplateVB/Addin/PanelFrame.vb
@@ -41,6 +41,9 @@ Public NotInheritable Class PanelFrame
     Private Const GW_CHILD As Integer = 5
     Private Const GW_HWNDNEXT As Integer = 2
 
+    Private Const GWL_EXSTYLE As Integer = (-20)
+    Private Const WS_EX_COMPOSITED As Integer = &H2000000
+
     <StructLayout(LayoutKind.Sequential, CharSet:=CharSet.Auto)> _
     Private Structure RECT
         Public left As Integer
@@ -78,12 +81,11 @@ Public NotInheritable Class PanelFrame
     Public Sub DestroyWindow()
         Try
             If _visioWindow IsNot Nothing AndAlso _form IsNot Nothing Then
-                Dim childWindowHandle = _form.Handle
 
                 _form.Hide()
 
-                SetWindowLong(childWindowHandle, GWL_STYLE, WS_OVERLAPPED)
-                SetParent(childWindowHandle, CType(0, IntPtr))
+                SetWindowLong(_form.Handle, GWL_STYLE, WS_OVERLAPPED)
+                SetParent(_form.Handle, CType(0, IntPtr))
 
                 _visioWindow.Close()
                 _visioWindow = Nothing
@@ -110,19 +112,17 @@ Public NotInheritable Class PanelFrame
             End If
 
             If _form IsNot Nothing Then
-                Dim childWindowHandle As IntPtr = _form.Handle
 
-                _visioWindow = visioParentWindow.Windows.Add(_form.Text, CInt(VisWindowStates.visWSDockedRight) Or CInt(VisWindowStates.visWSAnchorMerged), VisWinTypes.visAnchorBarAddon, 0, 0, 300, _
+                _visioWindow = visioParentWindow.Windows.Add(_form.Text, CInt(VisWindowStates.visWSDockedRight) Or CInt(VisWindowStates.visWSAnchorMerged) Or CInt(VisWindowStates.visWSVisible), VisWinTypes.visAnchorBarAddon, 0, 0, 300,
                                                              300, AddonWindowMergeId, String.Empty, 0)
 
                 AddHandler _visioWindow.BeforeWindowClosed, AddressOf OnBeforeWindowClosed
 
-                _visioWindow.Visible = False
-
                 Dim parentWindowHandle = CType(_visioWindow.WindowHandle32, IntPtr)
 
-                SetWindowLong(childWindowHandle, GWL_STYLE, WS_CHILD)
-                SetParent(childWindowHandle, parentWindowHandle)
+                SetWindowLong(_form.Handle, GWL_STYLE, WS_CHILD)
+                SetWindowLong(_form.Handle, GWL_EXSTYLE, WS_EX_COMPOSITED)
+                SetParent(_form.Handle, parentWindowHandle)
 
                 _form.Show()
 


### PR DESCRIPTION
workaround two-pixel width panel in multi-monitor scenario. Looks like Visio API opens a zer-width window in this case, if it's opened invisible. So now the panel opened immediately visible. To not break the redraw, WS_EX_COMPOSITE style added.